### PR TITLE
Serialize ScanFields and their bound/unbound values

### DIFF
--- a/src/main/scala/chiffre/InjectorInfo.scala
+++ b/src/main/scala/chiffre/InjectorInfo.scala
@@ -13,7 +13,7 @@
 // limitations under the License.
 package chiffre
 
-trait InjectorInfo extends HasWidth {
+trait InjectorInfo extends HasWidth with Equals {
   /* All configurable fields for this specific injector */
   val fields: Seq[ScanField]
 
@@ -44,6 +44,4 @@ trait InjectorInfo extends HasWidth {
   }
 
   override def hashCode = width
-
-  def canEqual(that: Any) = that.isInstanceOf[this.type]
 }

--- a/src/main/scala/chiffre/InjectorInfo.scala
+++ b/src/main/scala/chiffre/InjectorInfo.scala
@@ -31,4 +31,19 @@ trait InjectorInfo extends HasWidth {
   def toBits(): String = fields.map(_.toBits()).mkString
 
   def isBound(): Boolean = fields.map(_.isBound).reduceOption(_ && _).getOrElse(true)
+
+  def unbind(): InjectorInfo = {
+    fields.map(_.unbind)
+    this
+  }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: InjectorInfo => width == that.width &&
+        fields.zip(that.fields).foldLeft(true){ case (x, (l, r)) => x & (l == r) }
+    case _ => false
+  }
+
+  override def hashCode = width
+
+  def canEqual(that: Any) = that.isInstanceOf[this.type]
 }

--- a/src/main/scala/chiffre/ScanField.scala
+++ b/src/main/scala/chiffre/ScanField.scala
@@ -25,7 +25,7 @@ trait HasName {
 }
 
 /** A configurable field of the scan chain */
-trait ScanField extends HasName with HasWidth {
+trait ScanField extends HasName with HasWidth with Equals {
   var value: Option[BigInt] = None
 
   val name: String = this.getClass.getSimpleName
@@ -75,15 +75,6 @@ trait ScanField extends HasName with HasWidth {
   }
 
   override def hashCode = value.hashCode
-
-  /** Test that some object could possibly be equal to this
-    *
-    * '''You should not have to implement this. A `case class` that mixes
-    * in [[ScanField]] will have this defined automatically!'''
-    *
-    * @param that something else
-    */
-  def canEqual(that: Any): Boolean
 }
 
 trait ProbabilityBind { this: ScanField =>

--- a/src/main/scala/chiffre/ScanField.scala
+++ b/src/main/scala/chiffre/ScanField.scala
@@ -71,12 +71,19 @@ trait ScanField extends HasName with HasWidth {
   def isBound(): Boolean = value.nonEmpty
 
   override def equals(that: Any): Boolean = that match {
-    case that: ScanField => width == that.width && value == that.value
+    case that: ScanField => (this canEqual that) && (width == that.width) && (value == that.value)
   }
 
-  override def hashCode = width
+  override def hashCode = value.hashCode
 
-  def canEqual(that: Any) = that.isInstanceOf[this.type]
+  /** Test that some object could possibly be equal to this
+    *
+    * '''You should not have to implement this. A `case class` that mixes
+    * in [[ScanField]] will have this defined automatically!'''
+    *
+    * @param that something else
+    */
+  def canEqual(that: Any): Boolean
 }
 
 trait ProbabilityBind { this: ScanField =>

--- a/src/main/scala/chiffre/ScanField.scala
+++ b/src/main/scala/chiffre/ScanField.scala
@@ -46,7 +46,8 @@ trait ScanField extends HasName with HasWidth {
     if (in.nonEmpty) {
       bind(in.get)
     } else {
-      throw new ScanFieldUnboundException("Cannot bind to empty value")
+      value = None
+      this
     }
 
   lazy val maxValue = BigInt(2).pow(width) - 1
@@ -68,6 +69,14 @@ trait ScanField extends HasName with HasWidth {
   }
 
   def isBound(): Boolean = value.nonEmpty
+
+  override def equals(that: Any): Boolean = that match {
+    case that: ScanField => width == that.width && value == that.value
+  }
+
+  override def hashCode = width
+
+  def canEqual(that: Any) = that.isInstanceOf[this.type]
 }
 
 trait ProbabilityBind { this: ScanField =>

--- a/src/main/scala/chiffre/scan/JsonProtocol.scala
+++ b/src/main/scala/chiffre/scan/JsonProtocol.scala
@@ -39,11 +39,10 @@ object JsonProtocol {
 
   // Find all the classes in a ScanChain
   private def getClasses(scanChain: ScanChain): List[Class[_]] = scanChain
-    .map { case (k, v) => v.map(fc =>
+    .flatMap { case (k, v) => v.map(fc =>
             fc.injector.getClass +: fc.injector.fields.map(_.getClass)).foldLeft(List[Class[_]]())(_++_) }
-    .reduce(_++_)
-    .distinct
     .toList
+    .distinct
 
   // Find all the classes in some JSON
   private def getClasses(json: JValue): List[Class[_]] =

--- a/src/test/scala/chiffreTests/InjectorInfoSpec.scala
+++ b/src/test/scala/chiffreTests/InjectorInfoSpec.scala
@@ -16,22 +16,22 @@ package chiffreTests
 import chiffre.{InjectorInfo, ScanField}
 import chisel3.iotesters.ChiselFlatSpec
 
+case object EmptyInjectorInfo extends InjectorInfo {
+  val name = "DummyInjectorInfo"
+  val fields = Seq.empty
+}
+
 class InjectorInfoSpec extends ChiselFlatSpec {
 
   case class DummyField(width: Int) extends ScanField
-  class DummyInjectorInfo(val fields: Seq[ScanField]) extends InjectorInfo {
+  case class DummyInjectorInfo(fields: Seq[ScanField]) extends InjectorInfo {
     val name = "dummy"
   }
 
   behavior of "The InjectoInfo trait"
 
   it should "have width 0 and report bound if without fields" in {
-    class EmptyInjectorInfo extends InjectorInfo {
-      val name = "DummyInjectorInfo"
-      val fields = Seq.empty
-    }
-
-    val x = new EmptyInjectorInfo()
+    val x = EmptyInjectorInfo
     x.width should be (0)
     x.isBound should be (true)
   }

--- a/src/test/scala/chiffreTests/InstrumentationSpec.scala
+++ b/src/test/scala/chiffreTests/InstrumentationSpec.scala
@@ -26,10 +26,7 @@ class DummyController extends Module with ChiffreController {
 
 class DummyInjector extends Injector(1) with ChiffreInjector {
   val scanId = "dummy"
-  val info = new InjectorInfo {
-    val name = "dummyInfo"
-    val fields = Seq.empty
-  }
+  val info = EmptyInjectorInfo
 }
 
 class DummyInjectee extends Module with ChiffreInjectee {

--- a/src/test/scala/chiffreTests/ScanChainConfigSpec.scala
+++ b/src/test/scala/chiffreTests/ScanChainConfigSpec.scala
@@ -32,11 +32,22 @@ class ScanChainConfigSpec extends ChiselFlatSpec {
       FaultyComponent("Top.Top.z", CycleInjectorInfo(3, 8))
     )
   )
+  val scanFile = s"$test_dir/scan-chain.json"
+  writeScanChainToFile(scanChain, scanFile)
+
+  val scanChainBound: ScanChain = Map(
+    "id-0" -> Seq(
+      FaultyComponent("Top.Top.x", StuckAtInjectorInfo(5))
+    )
+  )
+  scanChainBound("id-0")(0).injector.fields(0).bind(1)
+  val scanBoundFile = s"$test_dir/scan-chain-partially-bound.json"
+  writeScanChainToFile(scanChainBound, scanBoundFile)
 
   def writeScanChainToFile(scanChain: ScanChain, fileName: String): Unit = {
     val dir = new File(test_dir)
     if (!dir.exists()) { dir.mkdirs() }
-    val file = new File(s"$test_dir/scan-chain.json")
+    val file = new File(fileName)
     val w = new FileWriter(file)
     w.write(JsonProtocol.serialize(scanChain))
     w.close()
@@ -45,8 +56,6 @@ class ScanChainConfigSpec extends ChiselFlatSpec {
   behavior of "ScanChainConfig"
 
   it should "error if missing command line arguments" in {
-    val scanFile = s"$test_dir/scan-chain.json"
-    writeScanChainToFile(scanChain, scanFile)
     val args = Array(scanFile)
     (the [ScanChainException] thrownBy {
       Driver.main(args)
@@ -54,8 +63,6 @@ class ScanChainConfigSpec extends ChiselFlatSpec {
   }
 
   it should "work if all command line arguments are specified" in {
-    val scanFile = s"$test_dir/scan-chain.json"
-    writeScanChainToFile(scanChain, scanFile)
     val args = Array("--probability", "0.5",
                      "--mask", "3",
                      "--stuck-at", "2",
@@ -63,6 +70,28 @@ class ScanChainConfigSpec extends ChiselFlatSpec {
                      "--cycle-inject", "4",
                      scanFile)
     Driver.main(args)
+  }
+
+  it should "not override existing fields" in {
+    val dir = s"$test_dir/override"
+    val args = Array("--mask", "3",
+                     "--stuck-at", "2",
+                     "--output-dir", dir,
+                     scanBoundFile)
+    Driver.main(args)
+
+    val roundTrip: ScanChain = JsonProtocol.deserialize(new File(s"$dir/bound.json"))
+    roundTrip("id-0")(0).injector.fields(0).value should be (Some(1))
+  }
+
+  it should "throw an exception if binding a bound field with --error-if-bound" in {
+    val args = Array("--mask", "3",
+                     "--stuck-at", "2",
+                     "--error-if-bound",
+                     scanBoundFile)
+    (the [ScanChainException] thrownBy {
+      Driver.main(args)
+    }).msg should startWith ("Tried to rebind already bound ScanField")
   }
 
   it should "properly compute the Fletcher checksum" in (pending)

--- a/src/test/scala/chiffreTests/ScanChainConfigSpec.scala
+++ b/src/test/scala/chiffreTests/ScanChainConfigSpec.scala
@@ -50,7 +50,7 @@ class ScanChainConfigSpec extends ChiselFlatSpec {
     val args = Array(scanFile)
     (the [ScanChainException] thrownBy {
       Driver.main(args)
-    }).msg should startWith ("Cannot bind ScanField")
+    }).msg should startWith ("Unable to bind")
   }
 
   it should "work if all command line arguments are specified" in {

--- a/src/test/scala/chiffreTests/ScanFieldSpec.scala
+++ b/src/test/scala/chiffreTests/ScanFieldSpec.scala
@@ -38,4 +38,33 @@ class ScanFieldSpec extends ChiselFlatSpec {
 
     (0 until x.maxValue.toInt + 1).foreach( v => v should be (backToInt(x.bind(v))))
   }
+
+  def equalityChecks( testName: String,
+                      fields: (ScanField, ScanField),
+                      tests: Map[(Option[Int], Option[Int]), Boolean]): Unit = it should s"$testName" in {
+    val (a, b) = fields
+    tests.map{ case ((x, y), pass) =>
+      a.bind(x.map(BigInt(_)))
+      b.bind(y.map(BigInt(_)))
+      val op = if (pass) "==" else "!="
+      info(s"""${x.getOrElse("unbound")} $op ${y.getOrElse("unbound")}""")
+      a == b should be (pass)
+    }
+  }
+
+  val sameTypeSameWidth = Map( (None, None)       -> true,
+                               (Some(1), None)    -> false,
+                               (Some(1), Some(1)) -> true,
+                               (Some(2), Some(1)) -> false,
+                               (None, Some(1))    -> false )
+  equalityChecks("compute equality correctly for fields of the same type and width",
+                 (DummyField(2), DummyField(2)), sameTypeSameWidth)
+
+  val allFalse = sameTypeSameWidth.map{ case (k, v) => (k -> false) }
+  equalityChecks("compute equality correctly for fields of the same type and different width",
+                 (DummyField(2), DummyField(3)), allFalse)
+
+  case class FooField(width: Int) extends ScanField
+  equalityChecks("compute equality correctly for fields of different types and the same widths",
+                 (DummyField(2), FooField(2)), allFalse)
 }

--- a/src/test/scala/chiffreTests/scan/JsonProtocolSpec.scala
+++ b/src/test/scala/chiffreTests/scan/JsonProtocolSpec.scala
@@ -13,26 +13,40 @@
 // limitations under the License.
 package chiffreTests.scan
 
-import chiffre.FaultyComponent
+import chiffre.{FaultyComponent, InjectorInfo}
 import chiffre.scan.{ScanChain, JsonProtocol}
 import chiffre.inject.{StuckAtInjectorInfo, LfsrInjectorInfo, CycleInjectorInfo}
 import chisel3.iotesters.ChiselFlatSpec
+
+case class TestInfo(hello: Option[Int] = None) extends InjectorInfo {
+  val fields = Seq.empty
+}
 
 class JsonProtocolSpec extends ChiselFlatSpec {
 
   val scanChain: ScanChain = Map(
     "id-0" -> Seq(
-      FaultyComponent("Top.Top.x", StuckAtInjectorInfo(5)),
-      FaultyComponent("Top.Top.y", LfsrInjectorInfo(4, 32)),
-      FaultyComponent("Top.Top.z", CycleInjectorInfo(3, 8))
+      FaultyComponent("Top.Top.a", StuckAtInjectorInfo(5)),
+      FaultyComponent("Top.Top.b", LfsrInjectorInfo(4, 32)),
+      FaultyComponent("Top.Top.c", CycleInjectorInfo(3, 8))
     )
   )
 
   behavior of "JsonProtocol"
 
   it should "round trip from ScanChain -> JSON -> ScanChain" in {
+
+    info("binding one of the values")
+    scanChain("id-0")(0).injector.fields(0).bind(BigInt(1))
     val json: String = JsonProtocol.serialize(scanChain)
+    println(json)
     val roundTrip: ScanChain = JsonProtocol.deserialize(json)
+
+    info("round trip matches with bound value")
     roundTrip should be (scanChain)
+
+    roundTrip("id-0")(0).injector.unbind
+    info("unbinding the bound value causes it to not match")
+    roundTrip should not be (scanChain)
   }
 }

--- a/src/test/scala/chiffreTests/scan/JsonProtocolSpec.scala
+++ b/src/test/scala/chiffreTests/scan/JsonProtocolSpec.scala
@@ -37,7 +37,7 @@ class JsonProtocolSpec extends ChiselFlatSpec {
   it should "round trip from ScanChain -> JSON -> ScanChain" in {
 
     info("binding one of the values")
-    scanChain("id-0")(0).injector.fields(0).bind(BigInt(1))
+    scanChain("id-0")(0).injector.fields(0).bind(1)
     val json: String = JsonProtocol.serialize(scanChain)
     println(json)
     val roundTrip: ScanChain = JsonProtocol.deserialize(json)


### PR DESCRIPTION
This adds custom serializers for `ScanField` and `InjectorInfo` that will include all scan fields and their bound/unbound values in scan chain JSON. Bound fields are serialized as a number (mapping to a `BigInt` in Scala) and unbound fields will show up as the String `null`.

Summary of changes:
  - Add InjectorInfo.unbind method to unbind all fields
  - Add equality methods for InjectorInfo and ScanField
  - Add InjectorInfo, ScanField serializers/deserializers
  - Change behavior of ScanChain.bind(BigInt) to bind None without error
  - Includes documentation of JsonProtocol
  - Causes ScanChainConfig utility to not override bound fields, but will error if requested (via command line argument)

An example of JSON output is below. The `Mask` is bound to 1 and the `StuckAt` is unbound:
```json
{
  "id-0":[
    {
      "name":"Top.Top.a",
      "injector":{
        "class":"chiffre.inject.StuckAtInjectorInfo",
        "bitWidth":5,
        "fields":[
          {
            "class":"chiffre.inject.Mask",
            "width":5,
            "value":1
          },
          {
            "class":"chiffre.inject.StuckAt",
            "width":5,
            "value":null
          }
        ]
      }
    }
  ]
}
```