### PR TITLE
Bump to Chisel 3.5.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,10 @@ addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.6" cross CrossVers
 assemblyJarName in assembly := "chiffre.jar"
 test in assembly := {}
 assemblyOutputPath in assembly := file("utils/bin/chiffre.jar")
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF", _*) => MergeStrategy.discard
+ case _                        => MergeStrategy.first
+}
 
 val defaultVersions = Map("chisel3" -> "3.5.6",
                           "chisel-iotesters" -> "2.5.6")

--- a/build.sbt
+++ b/build.sbt
@@ -29,18 +29,18 @@ name := "chiffre"
 version := "0.1-SNAPSHOT"
 scalacOptions := Seq("-deprecation", "-feature") ++ scalacOptionsVersion(scalaVersion.value)
 scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+crossScalaVersions := Seq("2.13.10", "2.12.17")
 libraryDependencies += "com.github.scopt" %% "scopt" % "3.6.0"
 libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.5.6" cross CrossVersion.full)
 
 /* Assembly */
 assemblyJarName in assembly := "chiffre.jar"
 test in assembly := {}
 assemblyOutputPath in assembly := file("utils/bin/chiffre.jar")
 
-val defaultVersions = Map("chisel3" -> "3.1.+",
-                          "chisel-iotesters" -> "1.2.+",
-                          "firrtl"  -> "1.1.+" )
+val defaultVersions = Map("chisel3" -> "3.5.6",
+                          "chisel-iotesters" -> "2.5.6")
 
 libraryDependencies ++= defaultVersions.map{ case (k, v) =>
   "edu.berkeley.cs" %% k % sys.props.getOrElse(k + "Version", v) }.toSeq

--- a/src/main/scala/chiffre/Instrumentation.scala
+++ b/src/main/scala/chiffre/Instrumentation.scala
@@ -14,14 +14,13 @@
 package chiffre
 
 import chisel3._
-import chisel3.core.BaseModule
 import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
 import chiffre.passes.{ScanChainAnnotation, FaultInjectionAnnotation,
   ScanChainTransform, FaultInstrumentationTransform}
 import chiffre.inject.Injector
 import chiffre.passes.ScanChainDescriptionAnnotation
 
-trait ChiffreController { this: BaseModule =>
+trait ChiffreController { this: RawModule =>
   /** Scan Chain Identifier used to differentiate scan chains. This must
     * be a `lazy val`. */
   def scanId: String
@@ -44,7 +43,7 @@ trait ChiffreInjector { this: Injector =>
   val scanId: String
 }
 
-trait ChiffreInjectee { this: BaseModule =>
+trait ChiffreInjectee { this: RawModule =>
 
   /** Make a specific signal run-time fault injectable
     *

--- a/src/main/scala/chiffre/ScanChain.scala
+++ b/src/main/scala/chiffre/ScanChain.scala
@@ -14,7 +14,6 @@
 package chiffre
 
 import chisel3._
-import chisel3.core.BaseModule
 
 class ScanIo extends Bundle {
   val clk = Input(Bool())
@@ -23,7 +22,7 @@ class ScanIo extends Bundle {
   val out = Output(Bool())
 }
 
-trait HasScanState { this: BaseModule =>
+trait HasScanState { this: RawModule =>
   val info: InjectorInfo
 }
 

--- a/src/main/scala/chiffre/inject/Injector.scala
+++ b/src/main/scala/chiffre/inject/Injector.scala
@@ -15,7 +15,6 @@ package chiffre.inject
 
 import chisel3._
 import chisel3.util.Cat
-import chisel3.core.BaseModule
 import chisel3.experimental.{ChiselAnnotation, annotate, RunFirrtlTransform}
 import chiffre.{ScanIo, HasScanState}
 

--- a/src/main/scala/chiffre/passes/FaultInstrumentationTransform.scala
+++ b/src/main/scala/chiffre/passes/FaultInstrumentationTransform.scala
@@ -16,7 +16,7 @@ package chiffre.passes
 import chiffre.inject.Injector
 
 import firrtl._
-import firrtl.passes.{ToWorkingIR, InferTypes, Uniquify, ExpandWhens, CheckInitialization, ResolveKinds, ResolveGenders,
+import firrtl.passes.{ToWorkingIR, InferTypes, Uniquify, ExpandWhens, CheckInitialization, ResolveKinds, ResolveFlows,
   CheckTypes}
 import firrtl.passes.wiring.WiringTransform
 import firrtl.annotations.{SingleTargetAnnotation, ComponentName}
@@ -46,7 +46,7 @@ class FaultInstrumentationTransform extends Transform {
     CheckInitialization,
     InferTypes,
     ResolveKinds,
-    ResolveGenders,
+    ResolveFlows,
     CheckTypes,
     new ScanChainTransform,
     new WiringTransform )

--- a/src/main/scala/chiffre/passes/ScanChainTransform.scala
+++ b/src/main/scala/chiffre/passes/ScanChainTransform.scala
@@ -128,7 +128,7 @@ class ScanChainTransform extends Transform {
     * @todo order the scan chain based on distance
     */
   def execute(state: CircuitState): CircuitState = {
-    val targetDir = new File(state.annotations.collectFirst{ case a: TargetDirAnnotation => a.value }.getOrElse("."))
+    val targetDir = new File(state.annotations.collectFirst{ case a: TargetDirAnnotation => a.directory }.getOrElse("."))
     val myAnnos = state.annotations.collect{ case a: ScanAnnos => a }
     myAnnos match {
       case Nil => state

--- a/src/test/scala/chiffreTests/InstrumentationSpec.scala
+++ b/src/test/scala/chiffreTests/InstrumentationSpec.scala
@@ -15,6 +15,7 @@ package chiffreTests
 
 import chisel3._
 import chisel3.iotesters.ChiselFlatSpec
+import chisel3.stage.ChiselStage
 import chiffre.{InjectorInfo, ChiffreController, ChiffreInjector, ChiffreInjectee}
 import chiffre.passes.{ScanChainAnnotation, ScanChainDescriptionAnnotation, FaultInjectionAnnotation}
 import chiffre.inject.{Injector, LfsrInjector32}
@@ -39,14 +40,14 @@ class InstrumentationSpec extends ChiselFlatSpec {
   behavior of "ChiffreController annotation"
 
   it should "emit a ScanChainAnnotation" in {
-    val circuit = Driver.elaborate(() => new DummyController)
+    val circuit = ChiselStage.elaborate(new DummyController)
     circuit.annotations.map(_.toFirrtl).collect{ case a: ScanChainAnnotation => a }.size should be (1)
   }
 
   behavior of "Chiffree Injectee annotation"
 
   it should "emit an annotation" in {
-    val circuit = Driver.elaborate(() => new DummyInjectee)
+    val circuit = ChiselStage.elaborate(new DummyInjectee)
     circuit.annotations.map(_.toFirrtl).collect{ case a: FaultInjectionAnnotation => a }.size should be (1)
   }
 }


### PR DESCRIPTION
This demonstrates getting this to work with Chisel 3.5.6. Due to the submodule dependency on perfect-chisel (which could be remove by using the upstream Chisel LFSR/PRNG library), this changes the git submodule to point at my private fork of`perfect-chisel`. The PR in https://github.com/IBM/perfect-chisel/pull/2 should merged first. Then this PR should be amended to not point at my fork of `perfect-chisel`.

Also, I removed my own push access to this repo almost two years ago, so I may be relying on @rbertran to merge this. (I think I gave you ownership back then?)

Alternatively, this may be lost and I can provide a working Chisel 3.5.6 version on my fork.